### PR TITLE
chore: add large blob history rewrite & guard workflows

### DIFF
--- a/.github/workflows/blob-size-guard.yml
+++ b/.github/workflows/blob-size-guard.yml
@@ -1,0 +1,40 @@
+name: Blob Size Guard
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan added blobs
+        env:
+          MAX_BLOB_BYTES: ${{ vars.MAX_BLOB_BYTES || 50000000 }}
+        run: |
+          echo "Threshold: $MAX_BLOB_BYTES bytes";
+          base_ref=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
+          git rev-list --objects --all > all.txt
+          mapfile -t new_objs < <(git rev-list --objects $base_ref..HEAD)
+          viol=0
+          for line in "${new_objs[@]}"; do
+            sha=$(echo "$line" | cut -d' ' -f1)
+            [ -z "$sha" ] && continue
+            size=$(git cat-file -s "$sha" 2>/dev/null || echo 0)
+            if [ "$size" -ge "$MAX_BLOB_BYTES" ]; then
+              path=$(echo "$line" | cut -d' ' -f2-)
+              echo "ERROR: blob $sha size $size path $path exceeds threshold";
+              viol=1
+            fi
+          done
+          if [ "$viol" -ne 0 ]; then
+            echo "Blob size violations detected."; exit 1; fi
+          echo "OK: No violations.";

--- a/.github/workflows/history-rewrite-large-blobs.yml
+++ b/.github/workflows/history-rewrite-large-blobs.yml
@@ -1,0 +1,141 @@
+name: History Rewrite (Large Blobs)
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type YES to allow force-push'
+        required: true
+        default: 'NO'
+      dry_run:
+        description: 'If true, only report (no rewrite)'
+        required: true
+        default: 'true'
+      size_threshold_mb:
+        description: 'Minimum blob size (MB) to purge'
+        required: true
+        default: '100'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: history-rewrite
+  cancel-in-progress: false
+
+jobs:
+  rewrite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Show initial repo size stats
+        run: |
+          git count-objects -v > before_size.txt
+          cat before_size.txt
+
+      - name: Enumerate large blobs
+        id: find
+        env:
+          THRESHOLD_BYTES: ${{ inputs.size_threshold_mb }}000000
+        run: |
+          echo "Scanning for blobs >= ${THRESHOLD_BYTES} bytes";
+          git rev-list --objects --all > all_objects.txt
+          > large_blobs.txt
+          > large_blob_shas.txt
+          while read sha path; do
+            [ -z "$sha" ] && continue
+            size=$(git cat-file -s "$sha" 2>/dev/null || echo 0)
+            if [ "$size" -ge "$THRESHOLD_BYTES" ]; then
+              echo "$size $sha $path" | tee -a large_blobs.txt
+              echo "$sha" >> large_blob_shas.txt
+            fi
+          done < <(git rev-list --objects --all)
+          sort -nr large_blobs.txt | head -50 | tee top50_large_blobs.txt || true
+          count=$(wc -l < large_blob_shas.txt | tr -d ' ')
+          echo "found_count=$count" >> $GITHUB_OUTPUT
+          if [ "$count" -eq 0 ]; then
+            echo "No blobs exceed threshold.";
+          fi
+
+      - name: Abort early if none & dry-run
+        if: steps.find.outputs.found_count == '0'
+        run: echo "No large blobs detected; nothing to do.";
+
+      - name: Install git-filter-repo
+        if: steps.find.outputs.found_count != '0' && inputs.dry_run == 'false'
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install git-filter-repo
+
+      - name: Rewrite history (purge large blobs)
+        if: steps.find.outputs.found_count != '0' && inputs.dry_run == 'false'
+        env:
+          CONFIRM: ${{ inputs.confirm }}
+        run: |
+          if [ "$CONFIRM" != "YES" ]; then
+            echo "CONFIRM not YES. Refusing to rewrite."; exit 1; fi
+          echo "Starting filter-repo purge for $(wc -l < large_blob_shas.txt) blobs";
+          python3 - <<'PY'
+import sys
+try:
+    import git_filter_repo as gfr
+except ImportError:
+    print('git-filter-repo not installed', file=sys.stderr)
+    sys.exit(2)
+with open('large_blob_shas.txt','r') as f:
+    targets={l.strip() for l in f if l.strip()}
+print(f'Purging {len(targets)} blobs')
+
+def blob_cb(blob, metadata):
+    if blob.oid in targets:
+        blob.data=b''
+
+gfr.FilterRepo(blob_callback=blob_cb).run()
+PY
+          echo "Rewrite complete";
+          git count-objects -v > after_size.txt
+
+      - name: Summarize differences
+        if: steps.find.outputs.found_count != '0'
+        run: |
+          if [ -f after_size.txt ]; then
+            echo "Repo size BEFORE:"; cat before_size.txt
+            echo "Repo size AFTER:"; cat after_size.txt
+          else
+            echo "(Dry run) Repo size BEFORE:"; cat before_size.txt
+          fi
+
+      - name: Prepare artifact bundle
+        run: |
+          mkdir artifacts
+          cp -f before_size.txt artifacts/ 2>/dev/null || true
+          [ -f after_size.txt ] && cp -f after_size.txt artifacts/ || true
+          cp -f large_blobs.txt artifacts/ 2>/dev/null || true
+          cp -f large_blob_shas.txt artifacts/ 2>/dev/null || true
+          cp -f top50_large_blobs.txt artifacts/ 2>/dev/null || true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: history-rewrite-diagnostics
+          path: artifacts
+          retention-days: 14
+
+      - name: Force push rewritten history
+        if: inputs.dry_run == 'false' && inputs.confirm == 'YES' && steps.find.outputs.found_count != '0'
+        run: |
+          current_branch=$(git symbolic-ref --short HEAD)
+          echo "Current branch: $current_branch"
+          if [ "$current_branch" != "main" ]; then
+            echo "Not on main; refusing to force push"; exit 1; fi
+          git remote -v
+          git push origin --force --tags
+
+      - name: Post-run note
+        run: |
+          echo "Done. Review artifacts for details.";

--- a/docs/repo-maintenance.md
+++ b/docs/repo-maintenance.md
@@ -1,0 +1,1 @@
+\n## History Rewrite Automation\nSee workflow 'History Rewrite (Large Blobs)' for procedure.\n

--- a/scripts/history_rewrite/audit_lfs_patterns.sh
+++ b/scripts/history_rewrite/audit_lfs_patterns.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+THRESHOLD_BYTES="${1:-15000000}" # 15MB default
+missing=0
+while read -r sha path; do
+  [ -z "$sha" ] && continue
+  size=$(git cat-file -s "$sha" 2>/dev/null || echo 0)
+  if [ "$size" -ge "$THRESHOLD_BYTES" ]; then
+    if [ -f "$path" ]; then
+      if ! grep -q "oid sha256:" "$path" 2>/dev/null; then
+        echo "MISSING LFS: $path ($size bytes)"
+        missing=1
+      fi
+    fi
+  fi
+done < <(git rev-list --objects HEAD | awk '{print $1" "$2}')
+exit $missing

--- a/scripts/history_rewrite/check_new_blob_sizes.sh
+++ b/scripts/history_rewrite/check_new_blob_sizes.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+THRESHOLD="${1:-50000000}"
+base_ref="${2:-origin/main}"
+viol=0
+while read -r line; do
+  sha=$(echo "$line" | cut -d' ' -f1)
+  [ -z "$sha" ] && continue
+  size=$(git cat-file -s "$sha" 2>/dev/null || echo 0)
+  if [ "$size" -ge "$THRESHOLD" ]; then
+    path=$(echo "$line" | cut -d' ' -f2-)
+    echo "Large blob detected: $sha size $size path $path" >&2
+    viol=1
+  fi
+done < <(git rev-list --objects "$base_ref"..HEAD)
+if [ $viol -ne 0 ]; then
+  echo "Blob size violations present" >&2
+  exit 1
+fi

--- a/scripts/history_rewrite/install_pre_push_hook.sh
+++ b/scripts/history_rewrite/install_pre_push_hook.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+THRESHOLD="${1:-50000000}"
+HOOK=.git/hooks/pre-push
+cat > "$HOOK" <<EOF
+#!/usr/bin/env bash
+max=$THRESHOLD
+viol=0
+while read local remote; do
+  range="$remote..$local"
+  [ -z "$remote" ] && range="$local"
+  for obj in $(git rev-list --objects $range); do
+    sha=$(echo $obj | cut -d' ' -f1)
+    size=$(git cat-file -s $sha 2>/dev/null || echo 0)
+    if [ "$size" -ge "$max" ]; then
+      path=$(echo $obj | cut -d' ' -f2-)
+      echo "ERROR: Blob $sha size $size path $path exceeds threshold $max" >&2
+      viol=1
+    fi
+  done
+done
+if [ $viol -ne 0 ]; then
+  echo "Push blocked due to large blobs." >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "$HOOK"
+echo "Installed pre-push hook with threshold $THRESHOLD bytes"

--- a/scripts/history_rewrite/large_blob_rewrite.py
+++ b/scripts/history_rewrite/large_blob_rewrite.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import sys
+try:
+    import git_filter_repo as gfr
+except ImportError:
+    print("git-filter-repo not installed", file=sys.stderr)
+    sys.exit(2)
+# Dynamic list: read from large_blob_shas.txt produced earlier
+try:
+    with open('large_blob_shas.txt','r') as f:
+        TARGETS={l.strip() for l in f if l.strip()}
+except FileNotFoundError:
+    print('large_blob_shas.txt missing', file=sys.stderr)
+    TARGETS=set()
+print(f'Rewriting {len(TARGETS)} blobs (emptying)')
+
+def blob_callback(blob, metadata):
+    if blob.oid in TARGETS:
+        blob.data=b''
+
+gfr.FilterRepo(blob_callback=blob_callback).run()


### PR DESCRIPTION
Adds CI-based large blob history rewrite workflow, blob size guard, and supporting scripts for pre-push & LFS audit. This enables Option B (GitHub Actions driven purge) without needing a local Linux environment.

Contents:
- .github/workflows/history-rewrite-large-blobs.yml (manual dispatch: enumerate blobs >= configurable threshold; dry-run or rewrite using git-filter-repo)
- .github/workflows/blob-size-guard.yml (enforces per-blob size threshold on PRs / pushes)
- scripts/history_rewrite/* (audit_lfs_patterns.sh, check_new_blob_sizes.sh, install_pre_push_hook.sh, large_blob_rewrite.py)
- docs/repo-maintenance.md (brief pointer section; can be expanded post-merge with actual rewrite metrics)

Next steps after merge:
1. Run History Rewrite (Large Blobs) workflow in dry_run mode with size_threshold_mb set high enough (e.g. 100) to list current offenders.
2. Review artifact (history-rewrite-diagnostics) to confirm target list.
3. Re-run with dry_run=false and confirm=YES (on main) to force-push purged history.
4. Broadcast re-clone instructions to collaborators.
5. Install pre-push hook locally via scripts/history_rewrite/install_pre_push_hook.sh.

Safety: Force push gated behind both confirm=YES and dry_run=false plus being on main.
